### PR TITLE
MB-13 refactor(Services): Añade capa API de usuarios (usuarioApi.js)

### DIFF
--- a/src/Services/api/usuarioApi.js
+++ b/src/Services/api/usuarioApi.js
@@ -1,0 +1,37 @@
+import { apiGet, apiPost, apiPut, apiDelete } from './apiService';
+
+export const usuarioApi = {
+    
+    obtenerTodos: async () => (
+      return await apiGet('/usuarios');
+    ),
+
+    obtenerPorId: async (id) => (
+        return await apiGet(`/usuarios/${id}`);
+    ),
+
+    actualizar: async (id,datos) => (
+        return await apiPut('/usuarios/${id', datos)
+    ),
+
+    eliminar: async (id) => (
+        return await apiDelete('/usuarios/${id');
+    ),
+
+    suspender: async (id) => (
+        return await apiPost('/usuarios/${id}/suspender');
+    ),
+
+    reactivar: async (id) => (
+        return await apiPost('/usuarios/${id}/reactivar');
+    ),
+
+    buscar: async (id) => (
+        return await apiGet('/usuarios/buscar?termino=${termino}');
+    ),
+
+    obtenerSuspendidos: async () => (
+        return await apiGet('/usuarios/suspendidos');
+    ),
+
+};


### PR DESCRIPTION
Capa de API de usuarios (usuarioApi.js)
Se añade una capa de cliente HTTP para el recurso de usuarios, que centraliza todas las peticiones al backend usando los helpers de apiService y deja preparado el proyecto para trabajar con una API REST real.

Cambios realizados
Cliente HTTP centralizado: Se crea usuarioApi.js en Services/api/ como único punto de llamadas al backend para usuarios.
Uso de apiService: Todas las peticiones pasan por apiGet, apiPost, apiPut y apiDelete, manteniendo base URL, headers y manejo de errores en un solo lugar.

Operaciones cubiertas:
Listado (obtenerTodos), detalle por id (obtenerPorId), actualización (actualizar), eliminación (eliminar), suspender/reactivar (suspender, reactivar), búsqueda (buscar) y listado de suspendidos (obtenerSuspendidos).
Contrato REST: Rutas y métodos alineados con convención REST (GET/PUT/POST/DELETE y paths como /usuarios, /usuarios/:id, etc.) para que el backend identifique cada acción por método + URL.

Impacto
La lógica de negocio (por ejemplo usuarioService o contextos) puede consumir la API de usuarios mediante una interfaz clara y async (usuarioApi.obtenerTodos(), usuarioApi.actualizar(id, datos), etc.), sin repetir fetch ni URLs. Cuando el backend esté disponible, bastará con configurar la base URL en apiService para que todas estas llamadas apunten al servidor.